### PR TITLE
Update the ArgumentParser text to fix usage message

### DIFF
--- a/pvacseq/lib/binding_filter.py
+++ b/pvacseq/lib/binding_filter.py
@@ -6,7 +6,7 @@ import csv
 
 
 def main(args_input = sys.argv[1:]):
-    parser = argparse.ArgumentParser("Binding Filter")
+    parser = argparse.ArgumentParser('pvacseq binding_filter')
     parser.add_argument('input', type=argparse.FileType('r'),
                         help="Input list of variants")
     parser.add_argument('fof', type=argparse.FileType('r'),

--- a/pvacseq/lib/generate_fasta.py
+++ b/pvacseq/lib/generate_fasta.py
@@ -45,7 +45,7 @@ def get_wildtype_subsequence_for_printing(position, wildtype_sequence, peptide_s
 
 
 def main(args_input = sys.argv[1:]):
-    parser = argparse.ArgumentParser("Generate Variant Sequences", description='')
+    parser = argparse.ArgumentParser('pvacseq generate_fasta')
     parser.add_argument('input_file', type=argparse.FileType('r'), help='input list of variants',)
     parser.add_argument('peptide_sequence_length', type=int, help='length of the peptide sequence')
     parser.add_argument('output_file', type=argparse.FileType('w'), help='output FASTA file')

--- a/pvacseq/lib/generate_fasta_key.py
+++ b/pvacseq/lib/generate_fasta_key.py
@@ -4,7 +4,7 @@ import re
 import sys
 
 def main(args_input = sys.argv[1:]):
-    parser = argparse.ArgumentParser("Generate Fasta Key", description='')
+    parser = argparse.ArgumentParser('pvacseq generate_fasta_key')
     parser.add_argument('input_file', type=argparse.FileType('r'), help="input FASTA file with variant sequences for wildtype(WT) and mutant(MT) proteins generated using 'GenerateVariantSequences.pl' and filtered using 'FilterSeq.pl'")
     parser.add_argument('output_file', type=argparse.FileType('w'), help='output Key file for lookup')
 

--- a/pvacseq/lib/main.py
+++ b/pvacseq/lib/main.py
@@ -9,7 +9,7 @@ except ValueError:
 
 
 def main(args_input = sys.argv[1:]):
-    parser = argparse.ArgumentParser("pVAC-Seq Main")
+    parser = argparse.ArgumentParser("pvacseq run")
 
     parser.add_argument("input",
                         help="Input TSV File with variants (please provide complete path)"

--- a/pvacseq/lib/parse_output.py
+++ b/pvacseq/lib/parse_output.py
@@ -55,7 +55,7 @@ def parse_input(input_file, key_file):
     return sorted_netmhc_result_list
 
 def main(args_input = sys.argv[1:]):
-    parser = argparse.ArgumentParser("Parse NetMHC Output", description='')
+    parser = argparse.ArgumentParser('pvacseq parse_output')
     parser.add_argument('input_file', type=argparse.FileType('r'), help='Raw output file from Netmhc',)
     parser.add_argument('key_file', type=argparse.FileType('r'), help='Key file for lookup of FASTA IDs')
     parser.add_argument('output_file', type=argparse.FileType('w'), help='Parsed output file')


### PR DESCRIPTION
Currently the text used in each ArgumentParser is used in the usage message for that command. For example, `pvacseq generate_fasta` would have a usage message of 
`
usage: Generate Variant Sequences [-h]
                                  input_file peptide_sequence_length
                                  output_file
`

With this PR it would read `usage: pvacseq generate_fasta [..]`