### PR TITLE
Removed Split command

### DIFF
--- a/pvacseq/lib/main.py
+++ b/pvacseq/lib/main.py
@@ -100,7 +100,6 @@ def main(args_input = sys.argv[1:]):
     tmp_dir = tempfile.TemporaryDirectory()
     tmp_split_fasta_prefix = os.path.join(tmp_dir.name, args.sample_name + "_" + str(args.peptide_sequence_length) + ".fa.split")
 
-    # run(['split', '--lines=400', fasta_file_path, tmp_split_fasta_prefix], check=True)
     split_reader = open(fasta_file_path, mode='r')
     split_counter = 0
     for chunk in split_file(split_reader, 400):

--- a/pvacseq/lib/main.py
+++ b/pvacseq/lib/main.py
@@ -12,7 +12,7 @@ import tempfile
 try:
     from .. import lib
 except ValueError:
-    import lib 
+    import lib
 from lib import pvacseq_utils
 
 def prediction_method_lookup(prediction_method):
@@ -100,8 +100,16 @@ def main(args_input = sys.argv[1:]):
     tmp_dir = tempfile.TemporaryDirectory()
     tmp_split_fasta_prefix = os.path.join(tmp_dir.name, args.sample_name + "_" + str(args.peptide_sequence_length) + ".fa.split")
 
-    run(['split', '--lines=400', fasta_file_path, tmp_split_fasta_prefix], check=True)
+    # run(['split', '--lines=400', fasta_file_path, tmp_split_fasta_prefix], check=True)
+    split_reader = open(fasta_file_path, mode='r')
+    split_counter = 0
+    for chunk in split_file(split_reader, 400):
+        split_writer = open("%s_%d"%(tmp_split_fasta_prefix, split_counter), mode='w')
+        split_writer.writelines(chunk)
+        split_writer.close()
+        split_counter += 1
     split_fasta_files = glob.glob("%s*" % tmp_split_fasta_prefix)
+    split_reader.close()
 
     iedb_output_files = []
     for method in args.prediction_algorithms:
@@ -142,6 +150,7 @@ def main(args_input = sys.argv[1:]):
                 print("Completed")
 
     input_files = []
+    tmp_dir.cleanup()
 
     for epl in args.epitope_length:
         for a in args.allele:
@@ -174,6 +183,16 @@ def main(args_input = sys.argv[1:]):
           "contains list of binding-filtered putative neoantigens")
     print("We recommend appending coverage information and running CoverageFilters.py to filter based on sequencing coverage information")
 
+
+def split_file(reader, lines=400):
+    from itertools import islice, chain
+    tmp = next(reader)
+    while tmp!="":
+        yield chain([tmp], islice(reader, lines-1))
+        try:
+            tmp = next(reader)
+        except StopIteration:
+            return
 
 if __name__ == '__main__':
     main()

--- a/tests/test_pvacseq.py
+++ b/tests/test_pvacseq.py
@@ -169,30 +169,21 @@ class PVACTests(unittest.TestCase):
     def test_split_file(self):
         import random
         random.seed()
-        test_dir = tempfile.TemporaryDirectory()
-        prefix = os.path.join(test_dir.name, 'split_file_')
-        writer = open(prefix+"source", mode='w')
+        source_file = tempfile.NamedTemporaryFile()
+        writer = open(source_file.name, mode='w')
         writer.writelines(
             "".join(chr(random.randint(32,255)) for i in range(25))+"\n"
             for line in range(500)
         )
         writer.close()
         for trial in range(5):
-            reader = open(prefix+"source", mode='r')
+            reader = open(source_file.name, mode='r')
             counter = 0
+            total = 0
             split = random.randint(10,500)
             for chunk in pvacseq.lib.main.split_file(reader, split):
-                writer = open(prefix+"output_%d_%d"%(trial, counter), mode='w')
-                counter+=1
-                writer.writelines(chunk)
-                writer.close()
-            total = 0
-            reader.close()
-            for i in range(counter):
-                reader = open(prefix+"output_%d_%d"%(trial, i), mode='r')
-                lines = len(reader.read().strip().split("\n"))
-                reader.close()
+                lines = len([line for line in chunk])
                 self.assertLessEqual(lines, split)
                 total+=lines
             self.assertEqual(total, 500)
-        test_dir.cleanup()
+            reader.close()

--- a/tests/test_pvacseq.py
+++ b/tests/test_pvacseq.py
@@ -165,3 +165,34 @@ class PVACTests(unittest.TestCase):
             False
         ))
         output_dir.cleanup()
+
+    def test_split_file(self):
+        import random
+        random.seed()
+        test_dir = tempfile.TemporaryDirectory()
+        prefix = os.path.join(test_dir.name, 'split_file_')
+        writer = open(prefix+"source", mode='w')
+        writer.writelines(
+            "".join(chr(random.randint(32,255)) for i in range(25))+"\n"
+            for line in range(500)
+        )
+        writer.close()
+        for trial in range(5):
+            reader = open(prefix+"source", mode='r')
+            counter = 0
+            split = random.randint(10,500)
+            for chunk in pvacseq.lib.main.split_file(reader, split):
+                writer = open(prefix+"output_%d_%d"%(trial, counter), mode='w')
+                counter+=1
+                writer.writelines(chunk)
+                writer.close()
+            total = 0
+            reader.close()
+            for i in range(counter):
+                reader = open(prefix+"output_%d_%d"%(trial, i), mode='r')
+                lines = len(reader.read().strip().split("\n"))
+                reader.close()
+                self.assertLessEqual(lines, split)
+                total+=lines
+            self.assertEqual(total, 500)
+        test_dir.cleanup()


### PR DESCRIPTION
The `split` command is valid on OS X and linux, but not windows, so I've replaced it with a python equivalent to remain platform independent