### PR TITLE
Handle empty FPKM fields

### DIFF
--- a/pvacseq/lib/coverage_filter.py
+++ b/pvacseq/lib/coverage_filter.py
@@ -116,12 +116,12 @@ def main(args_input = sys.argv[1:]):
             if trvaf < args.trna_vaf:
                 continue
 
-        if 'Gene Exp FPKM' in entry:
+        if 'Gene Exp FPKM' in entry and entry['Gene Exp FPKM']:
             fpkm  = float(entry['Gene Exp FPKM'])
             if fpkm < args.expn_val:
                 continue
 
-        if 'Transcript Exp FPKM' in entry:
+        if 'Transcript Exp FPKM' in entry and entry['Transcript Exp FPKM']:
             fpkm  = float(entry['Transcript Exp FPKM'])
             if fpkm < args.expn_val:
                 continue


### PR DESCRIPTION
FPKM entries for some variants may be empty after the cufflinks files are appended to the tsv. If one of those variants makes it all the way to this step than this step would fail.