### PR TITLE
Support a local install path for IEDB

### DIFF
--- a/pvacseq/lib/call_iedb.py
+++ b/pvacseq/lib/call_iedb.py
@@ -44,7 +44,7 @@ def main(args_input = sys.argv[1:]):
     if isinstance(prediction_class_object, MHCI):
         prediction_class.check_length_valid_for_allele(args.epitope_length, args.allele)
 
-    if args.epitope_length is None and isinstance(prediction_class_object, MHCI):
+    if args.epitope_length is None and prediction_class_object.needs_epitope_length:
         sys.exit("Epitope length is required for class I binding predictions")
 
     if args.iedb_executable_path is not None:

--- a/pvacseq/lib/call_iedb.py
+++ b/pvacseq/lib/call_iedb.py
@@ -9,6 +9,7 @@ import re
 import os
 from lib.prediction_class import *
 import time
+from subprocess import run, PIPE
 
 def main(args_input = sys.argv[1:]):
     parser = argparse.ArgumentParser('pvacseq call_iedb')
@@ -29,6 +30,10 @@ def main(args_input = sys.argv[1:]):
         help="Number of retries when making requests to the IEDB RESTful web interface. Must be less than or equal to 100."
              + "Default: 5"
     )
+    parser.add_argument(
+        "-e", "--iedb-executable-path",
+        help="The executable path of the local IEDB install"
+    )
     args = parser.parse_args(args_input)
 
     PredictionClass.check_alleles_valid([args.allele])
@@ -42,30 +47,37 @@ def main(args_input = sys.argv[1:]):
     if args.epitope_length is None and isinstance(prediction_class_object, MHCI):
         sys.exit("Epitope length is required for class I binding predictions")
 
-    data = {
-        'sequence_text': args.input_file.read(),
-        'method':        args.method,
-        'allele':        args.allele,
-    }
-    if args.epitope_length is not None:
-        data['length'] = args.epitope_length
+    if args.iedb_executable_path is not None:
+        response = run(prediction_class_object.iedb_executable_params(args), stdout=PIPE)
+        response_text = response.stdout
+        output_mode = 'wb'
+    else:
+        data = {
+            'sequence_text': args.input_file.read(),
+            'method':        args.method,
+            'allele':        args.allele,
+        }
+        if args.epitope_length is not None:
+            data['length'] = args.epitope_length
 
-    url = prediction_class_object.url
+        url = prediction_class_object.url
 
-    response = requests.post(url, data=data)
-    retries = 0
-    while response.status_code == 500 and retries < args.iedb_retries:
-        time.sleep(2 * retries)
         response = requests.post(url, data=data)
-        print("IEDB: Retry %s of %s" % (retries, args.iedb_retries))
-        retries += 1
+        retries = 0
+        while response.status_code == 500 and retries < args.iedb_retries:
+            time.sleep(2 * retries)
+            response = requests.post(url, data=data)
+            print("IEDB: Retry %s of %s" % (retries, args.iedb_retries))
+            retries += 1
 
-    if response.status_code != 200:
-        sys.exit("Error posting request to IEDB.\n%s" % response.text)
+        if response.status_code != 200:
+            sys.exit("Error posting request to IEDB.\n%s" % response.text)
+        response_text = response.text
+        output_mode = 'w'
 
     tmp_output_file = args.output_file + '.tmp'
-    tmp_output_filehandle = open(tmp_output_file, 'w')
-    tmp_output_filehandle.write(response.text)
+    tmp_output_filehandle = open(tmp_output_file, output_mode)
+    tmp_output_filehandle.write(response_text)
     tmp_output_filehandle.close()
     os.replace(tmp_output_file, args.output_file)
 

--- a/pvacseq/lib/main.py
+++ b/pvacseq/lib/main.py
@@ -71,6 +71,10 @@ def define_parser():
         help="Length of the peptide sequence to use when creating the FASTA. Default: 21",
     )
     parser.add_argument(
+        "--iedb-install-directory",
+        help="Directory that containst the local installation of IEDB MHC I and/or MHC II"
+    )
+    parser.add_argument(
         "-i", "--additional-input-file-list",
         help="yaml file of additional files to be used as inputs, e.g. cufflinks output files. "
              + "For an example of this yaml file run `pvacseq config_files additional_input_file_list`."
@@ -254,6 +258,13 @@ def main(args_input = sys.argv[1:]):
         if args.epitope_length is None:
             sys.exit("Epitope length is required for class I binding predictions")
 
+        if args.iedb_install_directory:
+            iedb_mhc_i_executable = os.path.join(args.iedb_install_directory, 'mhc_i', 'src', 'predict_binding.py')
+            if not os.path.exists(iedb_mhc_i_executable):
+                sys.exit("IEDB MHC I executable path doesn't exist %s", iedb_mhc_i_executable)
+        else:
+            iedb_mhc_i_executable = None
+
         print("Executing MHC Class I predictions")
 
         output_dir = os.path.join(base_output_dir, 'MHC_Class_I')
@@ -262,6 +273,7 @@ def main(args_input = sys.argv[1:]):
         class_i_arguments = shared_arguments.copy()
         class_i_arguments['alleles']                 = class_i_alleles
         class_i_arguments['peptide_sequence_length'] = args.peptide_sequence_length
+        class_i_arguments['iedb_executable']         = iedb_mhc_i_executable
         class_i_arguments['epitope_lengths']         = args.epitope_length
         class_i_arguments['prediction_algorithms']   = class_i_prediction_algorithms
         class_i_arguments['output_dir']              = output_dir
@@ -270,6 +282,13 @@ def main(args_input = sys.argv[1:]):
         pipeline.execute()
 
     if len(class_ii_prediction_algorithms) > 0 and len(class_ii_alleles) > 0:
+        if args.iedb_install_directory:
+            iedb_mhc_ii_executable = os.path.join(args.iedb_install_directory, 'mhc_ii', 'mhc_II_binding.py')
+            if not os.path.exists(iedb_mhc_ii_executable):
+                sys.exit("IEDB MHC II executable path doesn't exist %s", iedb_mhc_ii_executable)
+        else:
+            iedb_mhc_ii_executable = None
+
         print("Executing MHC Class II predictions")
 
         output_dir = os.path.join(base_output_dir, 'MHC_Class_II')
@@ -278,6 +297,7 @@ def main(args_input = sys.argv[1:]):
         class_ii_arguments = shared_arguments.copy()
         class_ii_arguments['alleles']               = class_ii_alleles
         class_ii_arguments['prediction_algorithms'] = class_ii_prediction_algorithms
+        class_ii_arguments['iedb_executable']       = iedb_mhc_ii_executable
         class_ii_arguments['output_dir']            = output_dir
         class_ii_arguments['netmhc_stab']           = False
         pipeline = MHCIIPipeline(**class_ii_arguments)

--- a/pvacseq/lib/main.py
+++ b/pvacseq/lib/main.py
@@ -72,7 +72,7 @@ def define_parser():
     )
     parser.add_argument(
         "--iedb-install-directory",
-        help="Directory that containst the local installation of IEDB MHC I and/or MHC II"
+        help="Directory that contains the local installation of IEDB MHC I and/or MHC II"
     )
     parser.add_argument(
         "-i", "--additional-input-file-list",

--- a/pvacseq/lib/pipeline.py
+++ b/pvacseq/lib/pipeline.py
@@ -21,6 +21,7 @@ class Pipeline(metaclass=ABCMeta):
         self.alleles                     = kwargs['alleles']
         self.prediction_algorithms       = kwargs['prediction_algorithms']
         self.output_dir                  = kwargs['output_dir']
+        self.iedb_executable             = kwargs['iedb_executable']
         self.gene_expn_file              = kwargs['gene_expn_file']
         self.transcript_expn_file        = kwargs['transcript_expn_file']
         self.normal_snvs_coverage_file   = kwargs['normal_snvs_coverage_file']
@@ -364,6 +365,7 @@ class MHCIPipeline(Pipeline):
                             a,
                             '-l', str(epl),
                             '-r', str(self.iedb_retries),
+                            '-e', self.iedb_executable,
                         ])
                         print("Completed")
                         split_iedb_output_files.append(split_iedb_out)
@@ -453,6 +455,7 @@ class MHCIIPipeline(Pipeline):
                         iedb_method,
                         a,
                         '-r', str(self.iedb_retries),
+                        '-e', self.iedb_executable,
                     ])
                     print("Completed")
                     split_iedb_output_files.append(split_iedb_out)

--- a/pvacseq/lib/prediction_class.py
+++ b/pvacseq/lib/prediction_class.py
@@ -61,6 +61,11 @@ class PredictionClass(metaclass=ABCMeta):
 
     @property
     @abstractmethod
+    def needs_epitope_length(self):
+        pass
+
+    @property
+    @abstractmethod
     def iedb_prediction_method(self):
         pass
 
@@ -78,6 +83,10 @@ class MHCI(PredictionClass, metaclass=ABCMeta):
     @property
     def url(self):
         return 'http://tools-api.iedb.org/tools_api/mhci/'
+
+    @property
+    def needs_epitope_length(self):
+        return True
 
     @classmethod
     def prediction_classes(cls):
@@ -160,6 +169,10 @@ class MHCII(PredictionClass, metaclass=ABCMeta):
     @property
     def url(self):
         return 'http://tools-api.iedb.org/tools_api/mhcii/'
+
+    @property
+    def needs_epitope_length(self):
+        return False
 
     @classmethod
     def prediction_classes(cls):

--- a/pvacseq/lib/prediction_class.py
+++ b/pvacseq/lib/prediction_class.py
@@ -55,6 +55,10 @@ class PredictionClass(metaclass=ABCMeta):
     def valid_allele_names(self):
         pass
 
+    @abstractmethod
+    def iedb_executable_params(self, args):
+        pass
+
     @property
     @abstractmethod
     def iedb_prediction_method(self):
@@ -112,6 +116,16 @@ class MHCI(PredictionClass, metaclass=ABCMeta):
         if length not in valid_lengths:
             sys.exit("Length %s not valid for allele %s and method %s." % (length, allele, self.iedb_prediction_method))
 
+    def iedb_executable_params(self, args):
+        return [
+            'python2.7',
+            args.iedb_executable_path,
+            args.method,
+            args.allele,
+            str(args.epitope_length),
+            args.input_file.name,
+        ]
+
 class NetMHC(MHCI):
     @property
     def iedb_prediction_method(self):
@@ -168,6 +182,15 @@ class MHCII(PredictionClass, metaclass=ABCMeta):
         if not self.valid_allele_names_dict:
             self.valid_allele_names_dict = self.parse_iedb_allele_file()
         return self.valid_allele_names_dict
+
+    def iedb_executable_params(self, args):
+        return [
+            'python2.7',
+            args.iedb_executable_path,
+            args.method,
+            args.allele,
+            args.input_file.name,
+        ]
 
 class NetMHCIIpan(MHCII):
     @property


### PR DESCRIPTION
This implementation expects that both the IEDB mhc_i and mhc_ii packages are installed under the same directory. This directory is what is being passed in to `--iedb-install-directory`. It resolves the executable path from there.
