### PR TITLE
Fix an error when the last row in the input tsv happens to fall on the end of an even chunk.

### DIFF
--- a/pvacseq/lib/pipeline.py
+++ b/pvacseq/lib/pipeline.py
@@ -121,6 +121,8 @@ class Pipeline(metaclass=ABCMeta):
             for row in reader:
                 if skip == 0:
                     split_tsv_writer.writerow(row)
+                if row_count == total_row_count:
+                    break
                 if row_count % tsv_size == 0:
                     if skip == 0:
                         split_tsv_file.close()

--- a/pvacseq/lib/pipeline.py
+++ b/pvacseq/lib/pipeline.py
@@ -292,7 +292,7 @@ class Pipeline(metaclass=ABCMeta):
 
         status_message(
             "\n"
-            + "Done: pvacseq has completed. File %s contains list of filtered putative neoantigens" % self.final_path()
+            + "Done: pvacseq has completed. File %s contains list of filtered putative neoantigens. " % self.final_path()
             + "We recommend appending coverage information and running `pvacseq coverage_filter` to filter based on sequencing coverage information"
         )
         if self.keep_tmp_files is False:


### PR DESCRIPTION
Closes #227.

Previously, when the last row of the input tsv happens to be at the end of a chunk, we would open a new file handle but there wouldn't be any rows left to write to it. This would result in errors down the road.