### PR TITLE
Remove unneeded check for valid alleles and replace with a warning.

### DIFF
--- a/pvacseq/lib/main.py
+++ b/pvacseq/lib/main.py
@@ -192,8 +192,6 @@ def main(args_input = sys.argv[1:]):
     parser = define_parser()
     args = parser.parse_args(args_input)
 
-    PredictionClass.check_alleles_valid(args.allele)
-
     if "." in args.sample_name:
         sys.exit("Sample name cannot contain '.'")
 
@@ -229,6 +227,8 @@ def main(args_input = sys.argv[1:]):
             class_i_alleles.append(allele)
         if allele in MHCII.all_valid_allele_names():
             class_ii_alleles.append(allele)
+        if allele not in MHCI.all_valid_allele_names() and allele not in MHCII.all_valid_allele_names():
+            print("Allele %s not valid. Skipping." % allele)
 
     shared_arguments = {
         'input_file'                : args.input_file,

--- a/pvacseq/lib/main.py
+++ b/pvacseq/lib/main.py
@@ -223,11 +223,14 @@ def main(args_input = sys.argv[1:]):
     class_i_alleles = []
     class_ii_alleles = []
     for allele in sorted(set(args.allele)):
+        valid = 0
         if allele in MHCI.all_valid_allele_names():
             class_i_alleles.append(allele)
+            valid = 1
         if allele in MHCII.all_valid_allele_names():
             class_ii_alleles.append(allele)
-        if allele not in MHCI.all_valid_allele_names() and allele not in MHCII.all_valid_allele_names():
+            valid = 1
+        if not valid:
             print("Allele %s not valid. Skipping." % allele)
 
     shared_arguments = {


### PR DESCRIPTION
Since lines 214-220 will result in invalid alleles getting filtered out/skipped, we can just add a warning there instead of aborting the pipeline.

Closes #245.