### PR TITLE
use max epitope length instead of min for cutoff

### DIFF
--- a/pvacseq/lib/pipeline.py
+++ b/pvacseq/lib/pipeline.py
@@ -320,7 +320,7 @@ class MHCIPipeline(Pipeline):
             generate_fasta_params = [
                 split_tsv_file_path,
                 str(self.peptide_sequence_length),
-                str(min(self.epitope_lengths)),
+                str(max(self.epitope_lengths)),
                 split_fasta_file_path,
                 split_fasta_key_file_path,
             ]


### PR DESCRIPTION
When you run pvacseq with epitope lengths `9, 10`, for example, and the fasta sequence is 9 amino acids long, the previous version would throw an error when trying to process the sequence with an epitope length of 10 (sequence too short). Using the `max(epitope_length)` will prevent this by filtering out the fasta sequence in the above example with the caveat that we wouldn't get any results for it, not even for an epitope length of 9. I can't think of a good workaround that doesn't involve rewriting the whole pipeline.