### PR TITLE
Version compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 python:
-  - "3.3"
-  - "3.4"
   - "3.5"
   - "3.6"
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
+  - "3.3"
+  - "3.4"
   - "3.5"
+  - "3.6"
 before_install:
   - pip install PyVCF
   - pip install requests

--- a/pvacseq/lib/main.py
+++ b/pvacseq/lib/main.py
@@ -55,7 +55,7 @@ def define_parser():
         "-e", "--epitope-length", type=lambda s:[int(epl) for epl in s.split(',')],
         help="Length of subpeptides (neoepitopes) to predict. "
              + "Multiple epitope lengths can be specified using a comma-separated list. "
-             + "Typical epitope lengths vary between 8-11. " 
+             + "Typical epitope lengths vary between 8-11. "
              + "Required for Class I prediction algorithms",
     )
     parser.add_argument(

--- a/pvacseq/lib/pipeline.py
+++ b/pvacseq/lib/pipeline.py
@@ -5,7 +5,7 @@ import csv
 
 try:
     from .. import lib
-except ValueError:
+except (ImportError, SystemError, ValueError):
     import lib
 from lib.prediction_class import *
 from lib.input_file_converter import *

--- a/pvacseq/pvacseq.py
+++ b/pvacseq/pvacseq.py
@@ -5,7 +5,7 @@ import os
 import pkg_resources
 try:
     from . import lib
-except SystemError:
+except (ImportError, SystemError, ValueError):
     import lib
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@ from setuptools import setup
 import os
 
 import sys
-if sys.version_info < (3,5):
-    print("This python version is not supported:")
-    print(sys.version)
-    print("pVAC-Seq requires python 3.5 or greater")
-    sys.exit(1)
+# if sys.version_info < (3,5):
+#     print("This python version is not supported:")
+#     print(sys.version)
+#     print("pVAC-Seq requires python 3.5 or greater")
+#     sys.exit(1)
 
 data_files = []
 for dirpath, dirnames, filenames in os.walk("pvacseq/example_data"):

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@ from setuptools import setup
 import os
 
 import sys
-# if sys.version_info < (3,5):
-#     print("This python version is not supported:")
-#     print(sys.version)
-#     print("pVAC-Seq requires python 3.5 or greater")
-#     sys.exit(1)
+if sys.version_info < (3,5):
+    print("This python version is not supported:")
+    print(sys.version)
+    print("pVAC-Seq requires python 3.5 or greater")
+    sys.exit(1)
 
 data_files = []
 for dirpath, dirnames, filenames in os.walk("pvacseq/example_data"):

--- a/tests/test_pvacseq.py
+++ b/tests/test_pvacseq.py
@@ -104,16 +104,17 @@ class PVACTests(unittest.TestCase):
             "pvacseq.py"
             )
         usage_search = re.compile(r"usage: ")
-        for command in [
-            "binding_filter",
-            "coverage_filter",
-            "run",
-            "generate_protein_fasta",
-            "install_vep_plugin",
-            "download_example_data",
-            "valid_alleles",
-            "config_files",
-            ]:
+        result = run([sys.executable, pvac_script_path, '-h'], stdout=PIPE)
+        self.assertFalse(result.returncode)
+        command_list = [
+            re.sub(r'\s', '', command) for command in
+            re.search(
+                r"arguments:.*{(.+)}",
+                result.stdout.decode(),
+                re.S
+            ).group(1).split(',')
+        ]
+        for command in command_list:
             result = run([
                 sys.executable,
                 pvac_script_path,


### PR DESCRIPTION
Addresses some of the changes to import semantics in python 3.6

It shouldn't be too hard to maintain compatibility going forwards, but if that's something we don't intend to do, then just feel free to close this PR without merging.

Enabled travis testing on 3.6 as well, to make sure nothing breaks as we continue development primarily on 3.5

closes #296 