### PR TITLE
Paging, filtering, and sorting methods

### DIFF
--- a/pvacseq/server/config/swagger.yaml
+++ b/pvacseq/server/config/swagger.yaml
@@ -598,6 +598,25 @@ paths:
       description: "This endpoint returns a list of active pvacseq runs\n"
       operationId: "pvacseq.server.controllers.processes.processes"
       parameters:
+      - name: "filters"
+        in: "query"
+        description: "Array of filters to be applied. ex: size>200"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: 'csv'
+        default: "none"
+      - name: "sorting"
+        in: "query"
+        description: "Ordered array of ways to sort data, + before property name\
+        indicating ascending, - indicating descending. ex: +size,-fileID"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: 'csv'
+        default: "none"
       - name: "page"
         in: "query"
         description: "Page of information to return"

--- a/pvacseq/server/config/swagger.yaml
+++ b/pvacseq/server/config/swagger.yaml
@@ -96,52 +96,13 @@ paths:
       description: "Queries the input folder for a list of files ready to be used\
       in a new run of pVAC-Seq"
       operationId: "pvacseq.server.controllers.files.list_input"
-      parameters:
-      - name: "filters"
-        in: "query"
-        description: "Array of filters to be applied. ex: size>200"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: 'csv'
-        default: "none"
-      - name: "sorting"
-        in: "query"
-        description: "Ordered array of ways to sort data, + before property name\
-        indicating ascending, - indicating descending. ex: +size,-fileID"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: 'csv'
-        default: "none"
-      - name: "page"
-        in: "query"
-        description: "Page of information to return"
-        required: false
-        type: "integer"
-        default: 1
-      - name: "count"
-        in: "query"
-        description: "Number of objects to return per page"
-        required: false
-        type: "integer"
-        default: 10
       responses:
         200:
           description: "An object containing metadata and an array of input files"
           schema:
             type: "array"
             items:
-              type: "object"
-              properties:
-                _meta:
-                  $ref: "#/definitions/MetaData"
-                results:
-                  type: "array"
-                  items:
-                    $ref: "#/definitions/Result"
+              $ref: "#/definitions/Result"
         default:
           description: "Unexpected error"
           schema:
@@ -854,52 +815,13 @@ paths:
       the dropbox folder.  The user may drop result files into this folder to be\
       displayed in the frontend UI"
       operationId: "pvacseq.server.controllers.files.list_dropbox"
-      parameters:
-      - name: "filters"
-        in: "query"
-        description: "Array of filters to be applied. ex: size>200"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: 'csv'
-        default: "none"
-      - name: "sorting"
-        in: "query"
-        description: "Ordered array of ways to sort data, + before property name\
-        indicating ascending, - indicating descending. ex: +size,-fileID"
-        required: false
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: 'csv'
-        default: "+fileID"
-      - name: "page"
-        in: "query"
-        description: "Page of information to return"
-        required: false
-        type: "integer"
-        default: 1
-      - name: "count"
-        in: "query"
-        description: "Number of objects to return per page"
-        required: false
-        type: "integer"
-        default: 10
       responses:
         200:
           description: "An object containing metadata and a list of files in the dropbox"
           schema:
             type: "array"
             items:
-              type: "object"
-              properties:
-                _meta:
-                  $ref: "#/definitions/MetaData"
-                results:
-                  type: "array"
-                  items:
-                    $ref: "#/definitions/Result"
+              $ref: "#/definitions/Result"
         default:
           description: "Unexpected error"
           schema:

--- a/pvacseq/server/config/swagger.yaml
+++ b/pvacseq/server/config/swagger.yaml
@@ -62,7 +62,7 @@ paths:
         required: false
         type: "integer"
         default: 1
-      - name: "per_page"
+      - name: "count"
         in: "query"
         description: "Number of results to return per page"
         required: false
@@ -604,7 +604,7 @@ paths:
         required: false
         type: "integer"
         default: 1
-      - name: "per_page"
+      - name: "count"
         in: "query"
         description: "Number of objects to return per page"
         required: false
@@ -1160,7 +1160,7 @@ definitions:
       current_page:
         type: "integer"
         description: "The page of information being returned"
-      per_page:
+      count:
         type: "integer"
         description: "The number of items to return per page"
       total_pages:

--- a/pvacseq/server/config/swagger.yaml
+++ b/pvacseq/server/config/swagger.yaml
@@ -37,13 +37,51 @@ paths:
         items:
           type: "string"
         default: "default"
+      - name: "filters"
+        in: "query"
+        description: "Array of filters to be applied. ex: size>200"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: 'csv'
+        default: "none"
+      - name: "sorting"
+        in: "query"
+        description: "Ordered array of ways to sort data, + before property name\
+        indicating ascending, - indicating descending. ex: +size,-fileID"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: 'csv'
+        default: "none"
+      - name: "page"
+        in: "query"
+        description: "Page of results to return"
+        required: false
+        type: "integer"
+        default: 1
+      - name: "per_page"
+        in: "query"
+        description: "Number of results to return per page"
+        required: false
+        type: "integer"
+        default: 10
       responses:
         200:
-          description: "An array of results"
+          description: "An object containing metadata and an array of results"
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/Result"
+              type: "object"
+              properties:
+                _meta:
+                  $ref: "#/definitions/MetaData"
+                results:
+                  type: "array"
+                  items:
+                    $ref: "#/definitions/Result"
         default:
           description: "Unexpected error"
           schema:
@@ -559,6 +597,19 @@ paths:
       summary: "Get list of running processes"
       description: "This endpoint returns a list of active pvacseq runs\n"
       operationId: "pvacseq.server.controllers.processes.processes"
+      parameters:
+      - name: "page"
+        in: "query"
+        description: "Page of information to return"
+        required: false
+        type: "integer"
+        default: 1
+      - name: "per_page"
+        in: "query"
+        description: "Number of objects to return per page"
+        required: false
+        type: "integer"
+        default: 10
       responses:
         200:
           description: "A list of active processes"
@@ -1103,6 +1154,21 @@ definitions:
         items: {
           type: "string"
         }
+  MetaData:
+    type: "object"
+    properties:
+      current_page:
+        type: "integer"
+        description: "The page of information being returned"
+      per_page:
+        type: "integer"
+        description: "The number of items to return per page"
+      total_pages:
+        type: "integer"
+        description: "The total number of pages of data"
+      total_count:
+        type: "integer"
+        description: "The total number of items"
   Error:
     type: "object"
     properties:

--- a/pvacseq/server/config/swagger.yaml
+++ b/pvacseq/server/config/swagger.yaml
@@ -96,13 +96,52 @@ paths:
       description: "Queries the input folder for a list of files ready to be used\
       in a new run of pVAC-Seq"
       operationId: "pvacseq.server.controllers.files.list_input"
+      parameters:
+      - name: "filters"
+        in: "query"
+        description: "Array of filters to be applied. ex: size>200"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: 'csv'
+        default: "none"
+      - name: "sorting"
+        in: "query"
+        description: "Ordered array of ways to sort data, + before property name\
+        indicating ascending, - indicating descending. ex: +size,-fileID"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: 'csv'
+        default: "none"
+      - name: "page"
+        in: "query"
+        description: "Page of information to return"
+        required: false
+        type: "integer"
+        default: 1
+      - name: "count"
+        in: "query"
+        description: "Number of objects to return per page"
+        required: false
+        type: "integer"
+        default: 10
       responses:
         200:
-          description: "An array of input files"
+          description: "An object containing metadata and an array of input files"
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/Result"
+              type: "object"
+              properties:
+                _meta:
+                  $ref: "#/definitions/MetaData"
+                results:
+                  type: "array"
+                  items:
+                    $ref: "#/definitions/Result"
         default:
           description: "Unexpected error"
           schema:
@@ -631,12 +670,19 @@ paths:
         default: 10
       responses:
         200:
-          description: "A list of active processes"
+          description: "An object containing metadata and a list of active processes"
           schema:
             type: "array"
-            items: {
-              $ref: "#/definitions/ProcessSummary"
-            }
+            items:
+              type: "object"
+              properties:
+                _meta:
+                  $ref: "#/definitions/MetaData"
+                results:
+                  type: "array"
+                  items: {
+                    $ref: "#/definitions/ProcessSummary"
+                  }
         default:
           description: "Unexpected error"
           schema:
@@ -813,13 +859,52 @@ paths:
       the dropbox folder.  The user may drop result files into this folder to be\
       displayed in the frontend UI"
       operationId: "pvacseq.server.controllers.files.list_dropbox"
+      parameters:
+      - name: "filters"
+        in: "query"
+        description: "Array of filters to be applied. ex: size>200"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: 'csv'
+        default: "none"
+      - name: "sorting"
+        in: "query"
+        description: "Ordered array of ways to sort data, + before property name\
+        indicating ascending, - indicating descending. ex: +size,-fileID"
+        required: false
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: 'csv'
+        default: "+fileID"
+      - name: "page"
+        in: "query"
+        description: "Page of information to return"
+        required: false
+        type: "integer"
+        default: 1
+      - name: "count"
+        in: "query"
+        description: "Number of objects to return per page"
+        required: false
+        type: "integer"
+        default: 10
       responses:
         200:
-          description: "Returns a list of files in the dropbox"
+          description: "An object containing metadata and a list of files in the dropbox"
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/Result"
+              type: "object"
+              properties:
+                _meta:
+                  $ref: "#/definitions/MetaData"
+                results:
+                  type: "array"
+                  items:
+                    $ref: "#/definitions/Result"
         default:
           description: "Unexpected error"
           schema:

--- a/pvacseq/server/config/swagger.yaml
+++ b/pvacseq/server/config/swagger.yaml
@@ -794,11 +794,6 @@ paths:
           description: "Returns object mapping each algorithm to an array of valid alleles for that algorithm"
           schema:
             type: "object"
-            properties:
-              default:
-                $ref: "#/definitions/MapItem"
-            additionalProperties:
-              $ref: "#/definitions/MapItem"
         default:
           description: "Unexpected error"
           schema:
@@ -1248,16 +1243,6 @@ definitions:
       description:
         type: "string"
         description: "A description of the file's contents in the context of pVAC-Seq"
-  MapItem:
-    type: "object"
-    properties:
-      algorithm:
-        type: "string"
-      alleles:
-        type: "array"
-        items: {
-          type: "string"
-        }
   MetaData:
     type: "object"
     properties:

--- a/pvacseq/server/controllers/database.py
+++ b/pvacseq/server/controllers/database.py
@@ -17,7 +17,6 @@ int_pattern = re.compile(r'^-?\d+$')
 NA_pattern = re.compile(r'^NA$')
 queryfilters = re.compile(r'(.+)(<=?|>=?|!=|==)(.+)')
 
-
 def init_column_mapping(row, schema):
     """Generate initial estimates of column data types"""
     defs = {column_filter(col): 'text' for col in row}

--- a/pvacseq/server/controllers/files.py
+++ b/pvacseq/server/controllers/files.py
@@ -52,7 +52,7 @@ def results_get(id, type, filters, sorting, page, count):
     return filterdata(output, filters, sorting, page, count)
 
 
-def list_input(filters, sorting, page, count, path = None):
+def list_input(path = None):
     """Fetches a list of input files from the input directory"""
     data = current_app.config['storage']['loader']()
     if not path:
@@ -79,7 +79,7 @@ def list_input(filters, sorting, page, count, path = None):
                 'type':'directory',
                 'contents': list_input(fullname)
             })
-    return filterdata(output, filters, sorting, page, count)
+    return output
 
 def results_getfile(id, fileID, count, page, filters, sort, direction):
     """(DEPRECATED) Read data directly from a specific output file"""
@@ -144,9 +144,9 @@ def results_getcols(id, fileID):
     raw_reader.close()
     return output
 
-def list_dropbox(filters, sorting, page, count):
+def list_dropbox():
     data = current_app.config['storage']['loader']()
-    return filterdata([
+    return [
         {
             'fileID':key,
             'description':entry['description'],
@@ -165,4 +165,4 @@ def list_dropbox(filters, sorting, page, count):
                 entry['display_name']
             )]).decode().split()[0])-1,
         } for (key, entry) in data['dropbox'].items()
-    ], filters, sorting, page, count)
+    ]

--- a/pvacseq/server/controllers/files.py
+++ b/pvacseq/server/controllers/files.py
@@ -49,11 +49,6 @@ def results_get(id, type, filters, sorting, page, count):
             for fileID in process[0]['files']:
                 if (re.search('%s.tsv'%filter, process[0]['files'][fileID]['display_name'])):
                     output.append(resultfile(id,process,fileID))
-    # can specify default filter and sorting per endpoint
-    if filters[0] == "none":
-        filters = []
-    if sorting[0] == "none":
-        sorting = []
     return filterdata(output, filters, sorting, page, count)
 
 

--- a/pvacseq/server/controllers/files.py
+++ b/pvacseq/server/controllers/files.py
@@ -52,7 +52,7 @@ def results_get(id, type, filters, sorting, page, count):
     return filterdata(output, filters, sorting, page, count)
 
 
-def list_input(path = None):
+def list_input(filters, sorting, page, count, path = None):
     """Fetches a list of input files from the input directory"""
     data = current_app.config['storage']['loader']()
     if not path:
@@ -79,7 +79,7 @@ def list_input(path = None):
                 'type':'directory',
                 'contents': list_input(fullname)
             })
-    return output
+    return filterdata(output, filters, sorting, page, count)
 
 def results_getfile(id, fileID, count, page, filters, sort, direction):
     """(DEPRECATED) Read data directly from a specific output file"""
@@ -144,9 +144,9 @@ def results_getcols(id, fileID):
     raw_reader.close()
     return output
 
-def list_dropbox():
+def list_dropbox(filters, sorting, page, count):
     data = current_app.config['storage']['loader']()
-    return [
+    return filterdata([
         {
             'fileID':key,
             'description':entry['description'],
@@ -165,4 +165,4 @@ def list_dropbox():
                 entry['display_name']
             )]).decode().split()[0])-1,
         } for (key, entry) in data['dropbox'].items()
-    ]
+    ], filters, sorting, page, count)

--- a/pvacseq/server/controllers/files.py
+++ b/pvacseq/server/controllers/files.py
@@ -22,7 +22,7 @@ def resultfile(id, process, fileID):
         ]).decode().split()[0])-1,
     })
 
-def results_get(id, type, filters, sorting, page, per_page):
+def results_get(id, type, filters, sorting, page, count):
     """Get the list of result files from a specific pVAC-Seq run"""
     data = current_app.config['storage']['loader']()
     if id == -1:
@@ -54,7 +54,7 @@ def results_get(id, type, filters, sorting, page, per_page):
         filters = []
     if sorting[0] == "none":
         sorting = []
-    return filterdata(output, filters, sorting, page, per_page)
+    return filterdata(output, filters, sorting, page, count)
 
 
 def list_input(path = None):

--- a/pvacseq/server/controllers/files.py
+++ b/pvacseq/server/controllers/files.py
@@ -5,12 +5,12 @@ from flask import current_app
 import subprocess
 from .processes import fetch_process, is_running
 from .database import filterfile
-from .utils import descriptions, column_filter
+from .utils import descriptions, column_filter, filterdata, sort, fullresponse
 
 # details for each file to be appended to the output of results_get
 def resultfile(id, process, fileID):
     return({
-        'fileID':fileID,
+        'fileID':int(fileID),
         'description':process[0]['files'][fileID]['description'],
         'display_name':process[0]['files'][fileID]['display_name'],
         'url':'/api/v1/processes/%d/results/%s'%(id, fileID),
@@ -22,7 +22,7 @@ def resultfile(id, process, fileID):
         ]).decode().split()[0])-1,
     })
 
-def results_get(id, type):
+def results_get(id, type, filters, sorting, page, per_page):
     """Get the list of result files from a specific pVAC-Seq run"""
     data = current_app.config['storage']['loader']()
     if id == -1:
@@ -49,7 +49,12 @@ def results_get(id, type):
             for fileID in process[0]['files']:
                 if (re.search('%s.tsv'%filter, process[0]['files'][fileID]['display_name'])):
                     output.append(resultfile(id,process,fileID))
-    return output
+    # can specify default filter and sorting per endpoint
+    if filters[0] == "none":
+        filters = []
+    if sorting[0] == "none":
+        sorting = []
+    return filterdata(output, filters, sorting, page, per_page)
 
 
 def list_input(path = None):

--- a/pvacseq/server/controllers/processes.py
+++ b/pvacseq/server/controllers/processes.py
@@ -6,7 +6,7 @@ import json
 import sys
 import subprocess
 from shlex import split
-from .utils import descriptions
+from .utils import descriptions, fullresponse
 from shutil import move as movetree
 
 spinner = re.compile(r'[\\\b\-/|]{2,}')
@@ -49,13 +49,13 @@ def fixpath(src, root, *keys):
         )
     return src
 
-def processes():
+def processes(page, per_page):
     """Returns a list of processes, and whether or not each process is running"""
     data = current_app.config['storage']['loader']()
     #Python comprehensions are great!
     # data['process-%d'%id]['returncode'] = process[1].returncode
     # data['process-%d'%id]['status'] = 1 if process[1].returncode == 0 else -1
-    return [
+    return fullresponse([
          {
              'id':proc[0],
              'running':is_running(proc[1]),
@@ -108,7 +108,7 @@ def processes():
                 )),
                 range(data['processid']+1)
             ) if 'process-%d'%(proc[0]) in data
-    ]
+    ], page, per_page)
 
 
 def process_info(id):

--- a/pvacseq/server/controllers/processes.py
+++ b/pvacseq/server/controllers/processes.py
@@ -49,7 +49,7 @@ def fixpath(src, root, *keys):
         )
     return src
 
-def processes(page, per_page):
+def processes(page, count):
     """Returns a list of processes, and whether or not each process is running"""
     data = current_app.config['storage']['loader']()
     #Python comprehensions are great!
@@ -108,7 +108,7 @@ def processes(page, per_page):
                 )),
                 range(data['processid']+1)
             ) if 'process-%d'%(proc[0]) in data
-    ], page, per_page)
+    ], page, count)
 
 
 def process_info(id):

--- a/pvacseq/server/controllers/processes.py
+++ b/pvacseq/server/controllers/processes.py
@@ -6,7 +6,7 @@ import json
 import sys
 import subprocess
 from shlex import split
-from .utils import descriptions, fullresponse
+from .utils import descriptions, filterdata
 from shutil import move as movetree
 
 spinner = re.compile(r'[\\\b\-/|]{2,}')
@@ -49,13 +49,13 @@ def fixpath(src, root, *keys):
         )
     return src
 
-def processes(page, count):
+def processes(filters, sorting, page, count):
     """Returns a list of processes, and whether or not each process is running"""
     data = current_app.config['storage']['loader']()
     #Python comprehensions are great!
     # data['process-%d'%id]['returncode'] = process[1].returncode
     # data['process-%d'%id]['status'] = 1 if process[1].returncode == 0 else -1
-    return fullresponse([
+    return filterdata([
          {
              'id':proc[0],
              'running':is_running(proc[1]),
@@ -108,7 +108,7 @@ def processes(page, count):
                 )),
                 range(data['processid']+1)
             ) if 'process-%d'%(proc[0]) in data
-    ], page, count)
+    ], filters, sorting, page, count)
 
 
 def process_info(id):

--- a/pvacseq/server/controllers/utils.py
+++ b/pvacseq/server/controllers/utils.py
@@ -17,6 +17,7 @@ import threading
 from postgresql.exceptions import UndefinedTableError
 from math import ceil
 import operator
+import pdb
 
 class dataObj(dict):
     def __init__(self, datafiles, sync):
@@ -618,7 +619,7 @@ def fullresponse(data, page, count):
     })
 
 def sort(data, sorting, page, count, columns):
-    if not len(sorting):
+    if not len(sorting) or sorting[0]=="none":
         return fullresponse(data, page, count)
     i = len(sorting)-1
     while i > -1:
@@ -640,7 +641,7 @@ def sort(data, sorting, page, count, columns):
     return fullresponse(data, page, count)
 
 def filterdata(data, filters, sorting, page, count):
-    if not len(data):
+    if not len(data) or filters[0]=="none":
         return fullresponse(data, page, count)
     columns = [name for name in data[0]]
     if not len(filters):

--- a/pvacseq/server/controllers/utils.py
+++ b/pvacseq/server/controllers/utils.py
@@ -606,20 +606,20 @@ def cmp(arg1, op, arg2):
     operation = ops.get(op)
     return operation(arg1,arg2)
 
-def fullresponse(data, page, per_page):
+def fullresponse(data, page, count):
     return ({
         "_meta": {
             "current_page":page,
-            "per_page":per_page,
-            "total_pages":ceil(len(data)/per_page),
+            "per_page":count,
+            "total_pages":ceil(len(data)/count),
             "total_count":len(data)
         },
-        "result": data[(per_page*(page-1)):((per_page*page)) if (per_page*page)<len(data) else len(data)]
+        "result": data[(count*(page-1)):((count*page)) if (count*page)<len(data) else len(data)]
     })
 
-def sort(data, sorting, page, per_page, columns):
+def sort(data, sorting, page, count, columns):
     if not len(sorting):
-        return fullresponse(data, page, per_page)
+        return fullresponse(data, page, count)
     i = len(sorting)-1
     while i > -1:
         col = sorting[i]
@@ -637,14 +637,14 @@ def sort(data, sorting, page, per_page, columns):
             }, 400)
         data = sorted(data, key=operator.itemgetter(col[1:]), reverse=True if col.startswith('-') else False)
         i-=1
-    return fullresponse(data, page, per_page)
+    return fullresponse(data, page, count)
 
-def filterdata(data, filters, sorting, page, per_page):
+def filterdata(data, filters, sorting, page, count):
     if not len(data):
-        return fullresponse(data, page, per_page)
+        return fullresponse(data, page, count)
     columns = [name for name in data[0]]
     if not len(filters):
-        return sort(data, sorting, page, per_page, columns)
+        return sort(data, sorting, page, count, columns)
     filteredlist = []
     for i in range(len(data)):
         comparisons = []
@@ -680,4 +680,4 @@ def filterdata(data, filters, sorting, page, per_page):
                 break
             if j == len(filters)-1:
                 filteredlist.append(data[i])
-    return sort(filteredlist, sorting, page, per_page, columns)
+    return sort(filteredlist, sorting, page, count, columns)

--- a/pvacseq/server/controllers/utils.py
+++ b/pvacseq/server/controllers/utils.py
@@ -607,6 +607,8 @@ def cmp(arg1, op, arg2):
     return operation(arg1,arg2)
 
 def fullresponse(data, page, count):
+    if count == -1:
+        count = len(data)
     return ({
         "_meta": {
             "current_page":page,

--- a/pvacseq/server/controllers/utils.py
+++ b/pvacseq/server/controllers/utils.py
@@ -15,6 +15,8 @@ import site
 import webbrowser
 import threading
 from postgresql.exceptions import UndefinedTableError
+from math import ceil
+import operator
 
 class dataObj(dict):
     def __init__(self, datafiles, sync):
@@ -156,7 +158,7 @@ def initialize(current_app, args):
         print(
             "pid's of old pVAC-Seq runs with id's",
             data['processid'],
-            "and lower may be innacurate"
+            "and lower may be inaccurate"
         )
     current_app.config['storage']['children']={}
     current_app.config['storage']['manifest']={}
@@ -173,7 +175,7 @@ def initialize(current_app, args):
             quote(visapp_path)
         ),
         shell=True,
-        stdout=subprocess.DEVNULL,
+        #stdout=subprocess.DEVNULL,
     )
     print(
         "Visualization server started on PID",
@@ -578,3 +580,104 @@ def initialize(current_app, args):
         # threading.Timer(2.5, lambda :webbrowser.open('http://localhost:8000')).start()
 
     print("Initialization complete.  Booting API")
+
+
+### filtering, sorting, and paging functions shared by multiple files ###
+queryfilters = re.compile(r'(.+)(<=?|>=?|!=|==)(.+)')
+
+ops = {
+    '<': operator.lt,
+    '<=': operator.le,
+    '==': operator.eq,
+    '!=': operator.ne,
+    '>=': operator.ge,
+    '>': operator.gt
+}
+
+# see if string is a number
+def is_number(string):
+    try:
+        float(string)
+        return True
+    except ValueError:
+        return False
+
+def cmp(arg1, op, arg2):
+    operation = ops.get(op)
+    return operation(arg1,arg2)
+
+def fullresponse(data, page, per_page):
+    return ({
+        "_meta": {
+            "current_page":page,
+            "per_page":per_page,
+            "total_pages":ceil(len(data)/per_page),
+            "total_count":len(data)
+        },
+        "result": data[(per_page*(page-1)):((per_page*page)) if (per_page*page)<len(data) else len(data)]
+    })
+
+def sort(data, sorting, page, per_page, columns):
+    if not len(sorting):
+        return fullresponse(data, page, per_page)
+    i = len(sorting)-1
+    while i > -1:
+        col = sorting[i]
+        if not col.startswith('-') and not col.startswith('+'):
+            return ({
+                "code": 400,
+                "message": "Please indicate which direction you'd like to sort by by putting a + or - in front of the column name",
+                "fields": "sorting"
+            }, 400)
+        if col[1:] not in columns:
+            return ({
+                "code": 400,
+                "message": "Unknown column name %s" % col[1:],
+                "fields": "sorting"
+            }, 400)
+        data = sorted(data, key=operator.itemgetter(col[1:]), reverse=True if col.startswith('-') else False)
+        i-=1
+    return fullresponse(data, page, per_page)
+
+def filterdata(data, filters, sorting, page, per_page):
+    if not len(data):
+        return fullresponse(data, page, per_page)
+    columns = [name for name in data[0]]
+    if not len(filters):
+        return sort(data, sorting, page, per_page, columns)
+    filteredlist = []
+    for i in range(len(data)):
+        comparisons = []
+        for j in range(len(filters)):
+            f = filters[j].strip()
+            if not len(f):
+                continue
+            result = queryfilters.match(f)
+            if not result:
+                return ({
+                    "code":400,
+                    "message": "Encountered an invalid filter (%s)" % f,
+                    "fields": "filtering"
+                }, 400)
+            colname = result.group(1)
+            if colname not in columns:
+                return ({
+                    "code": 400,
+                    "message": "Unknown column name %s" % result.group(1),
+                    "fields": "filtering"
+                }, 400)
+            op = result.group(2)
+            val = result.group(3)
+            comp = data[i][colname]
+            if type(comp) == int:
+                val = int(val)
+            # see if string is actually a number for accurate number comparisons,
+            # avoiding string comparisons of numbers in cmp() function
+            elif is_number(comp):
+                data[i]
+                val = float(val)
+            if not cmp(comp, op, val):
+                break
+            if j == len(filters)-1:
+                filteredlist.append(data[i])
+    return sort(filteredlist, sorting, page, per_page, columns)

--- a/pvacseq/server/controllers/utils.py
+++ b/pvacseq/server/controllers/utils.py
@@ -17,7 +17,6 @@ import threading
 from postgresql.exceptions import UndefinedTableError
 from math import ceil
 import operator
-import pdb
 
 class dataObj(dict):
     def __init__(self, datafiles, sync):
@@ -176,7 +175,7 @@ def initialize(current_app, args):
             quote(visapp_path)
         ),
         shell=True,
-        #stdout=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL
     )
     print(
         "Visualization server started on PID",
@@ -641,10 +640,10 @@ def sort(data, sorting, page, count, columns):
     return fullresponse(data, page, count)
 
 def filterdata(data, filters, sorting, page, count):
-    if not len(data) or filters[0]=="none":
+    if not len(data):
         return fullresponse(data, page, count)
     columns = [name for name in data[0]]
-    if not len(filters):
+    if not len(filters) or filters[0]=="none":
         return sort(data, sorting, page, count, columns)
     filteredlist = []
     for i in range(len(data)):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -382,7 +382,7 @@ class APITests(unittest.TestCase):
 
     def test_endpoint_process_results(self):
         response = requests.get(
-            self.urlBase + '/processes',
+            self.urlBase + '/processes?count=-1',
             timeout = 5
         )
         self.assertEqual(response.status_code,200)
@@ -390,7 +390,7 @@ class APITests(unittest.TestCase):
         if not len(process_list['result']):
             self.start_basic_run()
             response = requests.get(
-                self.urlBase + '/processes',
+                self.urlBase + '/processes?count=-1',
                 timeout = 5
             )
             self.assertEqual(response.status_code,200)
@@ -399,14 +399,14 @@ class APITests(unittest.TestCase):
         while process_list['result'][-1]['running']:
             time.sleep(1)
             response = requests.get(
-                self.urlBase + '/processes',
+                self.urlBase + '/processes?count=-1',
                 timeout = 5
             )
             self.assertEqual(response.status_code,200)
             process_list = response.json()
             process_list['result'].sort(key = lambda x:x['id'])
         response = requests.get(
-            'http://localhost:8080'+process_list['result'][-1]['results_url'],
+            'http://localhost:8080'+process_list['result'][-1]['results_url'] + '?count=-1',
             timeout = 5
         )
         self.assertEqual(response.status_code, 200, response.url+' : '+response.content.decode())
@@ -438,6 +438,17 @@ class APITests(unittest.TestCase):
             self.assertIn('url', item)
             self.assertIsInstance(item['url'], str)
             self.assertTrue(item['url'])
+
+        for process in process_list['result']:
+            response = requests.get(
+                # %2B = '+', %2C = ','
+                'http://localhost:8080' + process['results_url'] + '?type=final',
+                timeout = 5
+            )
+            self.assertEqual(response.status_code,200)
+            results = response.json()
+            for item in results['result']:
+                self.assertTrue(re.search('final.tsv$', item['display_name']))
 
     def test_endpoint_process_results_data(self):
         response = requests.get(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -671,6 +671,30 @@ class APITests(unittest.TestCase):
         self.assertEqual(response.status_code, 200, response.url+' : '+response.content.decode())
         self.assertFalse(response.json())
 
+    def test_endpoint_validallele(self):
+        response = requests.get(
+            self.urlBase+'/validalleles',
+            timeout=5,
+            params={
+                'prediction_algorithms':'NetMHC'
+            }
+        )
+        self.assertEqual(response.status_code, 200)
+        results = response.json()
+        self.assertIsInstance(results, dict)
+        self.assertTrue('NetMHC' in results)
+        self.assertTrue(len(results['NetMHC']))
+
+    def test_endpoint_validalgorithms(self):
+        response = requests.get(
+            self.urlBase+'/validalgorithms',
+            timeout=5
+        )
+        self.assertEqual(response.status_code, 200)
+        algorithms = response.json()
+        self.assertIsInstance(algorithms, list)
+        self.assertTrue('NetMHC' in algorithms)
+
     def test_duplicate_check(self):
         processID = self.start_basic_run()['processid']
         time.sleep(1)
@@ -847,7 +871,6 @@ class APITests(unittest.TestCase):
 
         for process in process_list['result']:
             response = requests.get(
-                # %2B = '+', %2C = ','
                 'http://localhost:8080' + process['results_url'],
                 timeout = 5,
                 params={

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -803,7 +803,7 @@ class APITests(unittest.TestCase):
     # In the future, maybe add more thorough testing of these
     def test_sort(self):
         response = requests.get(
-            self.urlBase + '/processes',
+            self.urlBase + '/processes?count=-1',
             timeout = 5
         )
         self.assertEqual(response.status_code,200)
@@ -811,7 +811,7 @@ class APITests(unittest.TestCase):
         if not len(process_list['result']):
             self.start_basic_run()
             response = requests.get(
-                self.urlBase + '/processes',
+                self.urlBase + '/processes?count=-1',
                 timeout = 5
             )
             self.assertEqual(response.status_code,200)
@@ -819,7 +819,7 @@ class APITests(unittest.TestCase):
         while process_list['result'][-1]['running']:
             time.sleep(1)
             response = requests.get(
-                self.urlBase + '/processes',
+                self.urlBase + '/processes?count=-1',
                 timeout = 5
             )
             self.assertEqual(response.status_code,200)
@@ -828,13 +828,13 @@ class APITests(unittest.TestCase):
         for process in process_list['result']:
             response = requests.get(
                 # %2B = '+', %2C = ','
-                'http://localhost:8080' + process['results_url'] + '?sorting=%2Bsize%2C%2BfileID',
+                'http://localhost:8080' + process['results_url'] + '?sorting=%2Bsize%2C%2BfileID&count=-1',
                 timeout = 5
             )
             result_list = response.json()
             self.assertEqual(response.status_code,200)
             response2 = requests.get(
-                'http://localhost:8080' + process['results_url'],
+                'http://localhost:8080' + process['results_url'] + '?count=-1',
                 timeout = 5
             )
             normal_result_list = response2.json()
@@ -844,7 +844,7 @@ class APITests(unittest.TestCase):
 
     def test_filter(self):
         response = requests.get(
-            self.urlBase + '/processes',
+            self.urlBase + '/processes?count=-1',
             timeout = 5
         )
         self.assertEqual(response.status_code,200)
@@ -852,7 +852,7 @@ class APITests(unittest.TestCase):
         if not len(process_list['result']):
             self.start_basic_run()
             response = requests.get(
-                self.urlBase + '/processes',
+                self.urlBase + '/processes?count=-1',
                 timeout = 5
             )
             self.assertEqual(response.status_code,200)
@@ -860,7 +860,7 @@ class APITests(unittest.TestCase):
         while process_list['result'][-1]['running']:
             time.sleep(1)
             response = requests.get(
-                self.urlBase + '/processes',
+                self.urlBase + '/processes?count=-1',
                 timeout = 5
             )
             self.assertEqual(response.status_code,200)
@@ -878,7 +878,7 @@ class APITests(unittest.TestCase):
 
     def test_pagination(self):
         response = requests.get(
-            self.urlBase + '/processes',
+            self.urlBase + '/processes?count=-1',
             timeout = 5
         )
         self.assertEqual(response.status_code,200)
@@ -886,7 +886,7 @@ class APITests(unittest.TestCase):
         if not len(process_list['result']):
             self.start_basic_run()
             response = requests.get(
-                self.urlBase + '/processes',
+                self.urlBase + '/processes?count=-1',
                 timeout = 5
             )
             self.assertEqual(response.status_code,200)
@@ -894,17 +894,17 @@ class APITests(unittest.TestCase):
         while process_list['result'][-1]['running']:
             time.sleep(1)
             response = requests.get(
-                self.urlBase + '/processes',
+                self.urlBase + '/processes?count=-1',
                 timeout = 5
             )
             self.assertEqual(response.status_code,200)
             process_list = response.json()
         for process in process_list['result']:
             response = requests.get(
-                'http://localhost:8080' + process['results_url'],
+                'http://localhost:8080' + process['results_url'] + '?count=-1',
                 timeout = 5
             )
-            result_list = response.json()
+            full_result_list = response.json()
             self.assertEqual(response.status_code,200)
             response = requests.get(
                 'http://localhost:8080' + process['results_url'] + '?count=3&page=2',
@@ -913,10 +913,10 @@ class APITests(unittest.TestCase):
             self.assertEqual(response.status_code,200)
             paged_result = response.json()
 
-            self.assertEqual(len(paged_result['result']), 3 if len(result_list['result']) >= 6 else len(result_list['result']) - 3)
+            self.assertEqual(len(paged_result['result']), 3 if len(full_result_list['result']) >= 6 else len(full_result_list['result']) - 3)
             self.assertEqual(paged_result['_meta']['per_page'], 3)
             self.assertEqual(paged_result['_meta']['current_page'], 2)
-            self.assertEqual(paged_result['_meta']['total_count'], len(result_list['result']))
-            self.assertEqual(paged_result['result'][0] if len(paged_result['result']) else [], result_list['result'][3] if len(result_list['result']) > 3 else [])
+            self.assertEqual(paged_result['_meta']['total_count'], len(full_result_list['result']))
+            self.assertEqual(paged_result['result'][0] if len(paged_result['result']) else [], full_result_list['result'][3] if len(full_result_list['result']) > 3 else [])
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -814,24 +814,33 @@ class APITests(unittest.TestCase):
     # In the future, maybe add more thorough testing of these
     def test_sort(self):
         response = requests.get(
-            self.urlBase + '/processes?count=-1',
-            timeout = 5
+            self.urlBase + '/processes',
+            timeout = 5,
+            params={
+                'count':-1
+            }
         )
         self.assertEqual(response.status_code,200)
         process_list = response.json()
         if not len(process_list['result']):
             self.start_basic_run()
             response = requests.get(
-                self.urlBase + '/processes?count=-1',
-                timeout = 5
+                self.urlBase + '/processes',
+                timeout = 5,
+                params={
+                    'count':-1
+                }
             )
             self.assertEqual(response.status_code,200)
             process_list = response.json()
         while process_list['result'][-1]['running']:
             time.sleep(1)
             response = requests.get(
-                self.urlBase + '/processes?count=-1',
-                timeout = 5
+                self.urlBase + '/processes',
+                timeout = 5,
+                params={
+                    'count':-1
+                }
             )
             self.assertEqual(response.status_code,200)
             process_list = response.json()
@@ -839,48 +848,69 @@ class APITests(unittest.TestCase):
         for process in process_list['result']:
             response = requests.get(
                 # %2B = '+', %2C = ','
-                'http://localhost:8080' + process['results_url'] + '?sorting=%2Bsize%2C%2BfileID&count=-1',
-                timeout = 5
+                'http://localhost:8080' + process['results_url'],
+                timeout = 5,
+                params={
+                    'sorting':'+size,+fileID',
+                    'count':-1
+                }
             )
-            result_list = response.json()
             self.assertEqual(response.status_code,200)
+            result_list = response.json()
+
             response2 = requests.get(
-                'http://localhost:8080' + process['results_url'] + '?count=-1',
-                timeout = 5
+                'http://localhost:8080' + process['results_url'],
+                timeout = 5,
+                params={
+                    'count':-1
+                }
             )
-            normal_result_list = response2.json()
             self.assertEqual(response2.status_code,200)
+            normal_result_list = response2.json()
             normal_result_list['result'].sort(key = lambda x: (x['size'], x['fileID']))
             self.assertEqual(result_list['result'], normal_result_list['result'])
 
     def test_filter(self):
         response = requests.get(
-            self.urlBase + '/processes?count=-1',
-            timeout = 5
+            self.urlBase + '/processes',
+            timeout = 5,
+            params={
+                'count':-1
+            }
         )
         self.assertEqual(response.status_code,200)
         process_list = response.json()
         if not len(process_list['result']):
             self.start_basic_run()
             response = requests.get(
-                self.urlBase + '/processes?count=-1',
-                timeout = 5
+                self.urlBase + '/processes',
+                timeout = 5,
+                params={
+                    'count':-1
+                }
             )
             self.assertEqual(response.status_code,200)
             process_list = response.json()
         while process_list['result'][-1]['running']:
             time.sleep(1)
             response = requests.get(
-                self.urlBase + '/processes?count=-1',
-                timeout = 5
+                self.urlBase + '/processes',
+                timeout = 5,
+                params={
+                    'count':-1
+                }
             )
             self.assertEqual(response.status_code,200)
             process_list = response.json()
-        for process in process_list['result']:
 
+        for process in process_list['result']:
             response = requests.get(
-                'http://localhost:8080' + process['results_url'] + '?filters=fileID>2',
-                timeout = 5
+                'http://localhost:8080' + process['results_url'],
+                timeout = 5,
+                params={
+                    'filters':'fileID>2'#,
+                    #'count':-1
+                }
             )
             filtered_results = response.json()
             self.assertEqual(response.status_code,200)
@@ -889,45 +919,62 @@ class APITests(unittest.TestCase):
 
     def test_pagination(self):
         response = requests.get(
-            self.urlBase + '/processes?count=-1',
-            timeout = 5
+            self.urlBase + '/processes',
+            timeout = 5,
+            params={
+                'count':-1
+            }
         )
         self.assertEqual(response.status_code,200)
         process_list = response.json()
         if not len(process_list['result']):
             self.start_basic_run()
             response = requests.get(
-                self.urlBase + '/processes?count=-1',
-                timeout = 5
+                self.urlBase + '/processes',
+                timeout = 5,
+                params={
+                    'count':-1
+                }
             )
             self.assertEqual(response.status_code,200)
             process_list = response.json()
         while process_list['result'][-1]['running']:
             time.sleep(1)
             response = requests.get(
-                self.urlBase + '/processes?count=-1',
-                timeout = 5
+                self.urlBase + '/processes',
+                timeout = 5,
+                params={
+                    'count':-1
+                }
             )
             self.assertEqual(response.status_code,200)
             process_list = response.json()
+
         for process in process_list['result']:
             response = requests.get(
-                'http://localhost:8080' + process['results_url'] + '?count=-1',
-                timeout = 5
+                'http://localhost:8080' + process['results_url'],
+                timeout = 5,
+                params={
+                    'count':-1
+                }
             )
-            full_result_list = response.json()
             self.assertEqual(response.status_code,200)
+            full_result_list = response.json()
             response = requests.get(
-                'http://localhost:8080' + process['results_url'] + '?count=3&page=2',
-                timeout = 5
+                'http://localhost:8080' + process['results_url'],
+                timeout = 5,
+                params={
+                    'count':3,
+                    'page':2
+                }
             )
             self.assertEqual(response.status_code,200)
             paged_result = response.json()
 
             self.assertEqual(len(paged_result['result']), 3 if len(full_result_list['result']) >= 6 else len(full_result_list['result']) - 3)
+            self.assertEqual(paged_result['result'][0] if len(paged_result['result']) else [], full_result_list['result'][3] if len(full_result_list['result']) > 3 else [])
             self.assertEqual(paged_result['_meta']['per_page'], 3)
             self.assertEqual(paged_result['_meta']['current_page'], 2)
             self.assertEqual(paged_result['_meta']['total_count'], len(full_result_list['result']))
-            self.assertEqual(paged_result['result'][0] if len(paged_result['result']) else [], full_result_list['result'][3] if len(full_result_list['result']) > 3 else [])
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -263,7 +263,7 @@ class APITests(unittest.TestCase):
             timeout = 5,
         )
         self.assertEqual(response.status_code, 200, response.url+' : '+response.content.decode())
-        targetResult = [item for item in response.json() if item['id'] == processID]
+        targetResult = [item for item in response.json()['result'] if item['id'] == processID]
         self.assertTrue(len(targetResult))
         targetResult = targetResult[0]
         self.assertIsInstance(targetResult, dict)
@@ -318,10 +318,10 @@ class APITests(unittest.TestCase):
         )
         self.assertEqual(response.status_code,200)
         process_list = response.json()
-        if not len(process_list):
+        if not len(process_list['result']):
             process_list = [{'id':self.start_basic_run()}]
         response = requests.get(
-            self.urlBase + '/processes/%d'%process_list[0]['id'],
+            self.urlBase + '/processes/%d'%process_list['result'][0]['id'],
             timeout=5,
         )
         self.assertEqual(response.status_code, 200, response.url+' : '+response.content.decode())
@@ -341,7 +341,7 @@ class APITests(unittest.TestCase):
         self.assertIsInstance(process_data['files'][0], dict)
 
         self.assertIn('id', process_data)
-        self.assertEqual(process_data['id'], process_list[0]['id'])
+        self.assertEqual(process_data['id'], process_list['result'][0]['id'])
 
         self.assertIn('log', process_data)
         self.assertIsInstance(process_data['log'], list)
@@ -387,7 +387,7 @@ class APITests(unittest.TestCase):
         )
         self.assertEqual(response.status_code,200)
         process_list = response.json()
-        if not len(process_list):
+        if not len(process_list['result']):
             self.start_basic_run()
             response = requests.get(
                 self.urlBase + '/processes',
@@ -395,8 +395,8 @@ class APITests(unittest.TestCase):
             )
             self.assertEqual(response.status_code,200)
             process_list = response.json()
-        process_list.sort(key = lambda x:x['id'])
-        while process_list[-1]['running']:
+        process_list['result'].sort(key = lambda x:x['id'])
+        while process_list['result'][-1]['running']:
             time.sleep(1)
             response = requests.get(
                 self.urlBase + '/processes',
@@ -404,15 +404,16 @@ class APITests(unittest.TestCase):
             )
             self.assertEqual(response.status_code,200)
             process_list = response.json()
-            process_list.sort(key = lambda x:x['id'])
+            process_list['result'].sort(key = lambda x:x['id'])
         response = requests.get(
-            'http://localhost:8080'+process_list[-1]['results_url'],
+            'http://localhost:8080'+process_list['result'][-1]['results_url'],
             timeout = 5
         )
         self.assertEqual(response.status_code, 200, response.url+' : '+response.content.decode())
         results = response.json()
-        self.assertIsInstance(results, list)
-        for item in results:
+        self.assertIsInstance(results, dict)
+        self.assertIsInstance(results['result'], list)
+        for item in results['result']:
             self.assertIsInstance(item, dict)
 
             self.assertIn('description', item)
@@ -424,7 +425,7 @@ class APITests(unittest.TestCase):
             self.assertTrue(item['display_name'])
 
             self.assertIn('fileID', item)
-            self.assertIsInstance(item['fileID'], str)
+            self.assertIsInstance(item['fileID'], int)
             self.assertGreaterEqual(int(item['fileID']), 0)
 
             self.assertIn('rows', item)
@@ -445,7 +446,7 @@ class APITests(unittest.TestCase):
         )
         self.assertEqual(response.status_code,200)
         process_list = response.json()
-        if not len(process_list):
+        if not len(process_list['result']):
             self.start_basic_run()
             response = requests.get(
                 self.urlBase + '/processes',
@@ -453,8 +454,8 @@ class APITests(unittest.TestCase):
             )
             self.assertEqual(response.status_code,200)
             process_list = response.json()
-        process_list.sort(key = lambda x:x['id'])
-        while process_list[-1]['running']:
+        process_list['result'].sort(key = lambda x:x['id'])
+        while process_list['result'][-1]['running']:
             time.sleep(1)
             response = requests.get(
                 self.urlBase + '/processes',
@@ -462,14 +463,14 @@ class APITests(unittest.TestCase):
             )
             self.assertEqual(response.status_code,200)
             process_list = response.json()
-            process_list.sort(key = lambda x:x['id'])
+            process_list['result'].sort(key = lambda x:x['id'])
         response = requests.get(
-            'http://localhost:8080'+process_list[-1]['results_url'],
+            'http://localhost:8080'+process_list['result'][-1]['results_url'],
             timeout = 5
         )
         self.assertEqual(response.status_code, 200, response.url+' : '+response.content.decode())
         results = response.json()
-        for item in results:
+        for item in results['result']:
             if item['display_name'].endswith('.tsv') and item['rows']>0:
                 response = requests.get(
                     'http://localhost:8080'+item['url'],


### PR DESCRIPTION
Based on issue #318 
end URL would be something like:
http://localhost:8080/api/v1/processes/2/results?sorting=%2Bsize%2C-fileID&filters=fileID>10&count=5&page=2
(since %2B = '+' and %2C = ',')

currently applies to: results, processes
originally added it to input and dropbox but removed to make staging easier

filters: comma delimited list of filters (filters must be column >, >=, <, <=, or == value, value can also be a string)
sorting: comma delimited list of sorting schematics, must add + or - before column name to indicate ascending or descending, list is ordered (in URL above, would sort by size first and then fileID)
page: page of results to return
count: number of results to return per page, -1 to return all results on one page